### PR TITLE
Feature/datastream/method/amount of data

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,13 @@ on:
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python_version: ['3.10', '3.11', '3.12', '3.13']
+        resolution: [lowest-direct, highest]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -22,7 +28,7 @@ jobs:
       run: pipx install poetry
     - uses: actions/setup-python@v5
       with:
-        python-version-file: pyproject.toml
+        python-version: ${{ matrix.python_version }}
         cache: poetry
     - name: Install dependencies
       run: |
@@ -37,6 +43,7 @@ jobs:
           --cov=src tests \
           --log-level=DEBUG \
           --verbose
+      shell: bash
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7
       with:

--- a/src/MOBI_QC/core/models/DataStream.py
+++ b/src/MOBI_QC/core/models/DataStream.py
@@ -116,8 +116,8 @@ class DataStream:
     ) -> tuple[float, float]:
         """Calculate amount of data within time range.
 
-        Calculate amount of data within filtered modality data for specified time 
-        range, based on LSL timestamps, and compare it with the expected amount in 
+        Calculate amount of data within filtered modality data for specified time
+        range, based on LSL timestamps, and compare it with the expected amount in
         that time range which is calculated from input onset and offset timestamps.
 
         Args:
@@ -126,7 +126,7 @@ class DataStream:
 
         Returns:
             A tuple containing:
-                - modality_amount: Amount of modality data within the specified 
+                - modality_amount: Amount of modality data within the specified
                 time range (in seconds).
                 - amount_percent: Percentage of expected amount that the modality
                 amount represents.
@@ -143,16 +143,20 @@ class DataStream:
         if offset_timestamp <= onset_timestamp:
             raise ValueError("Offset timestamp must be greater than onset timestamp.")
 
-        if (onset_timestamp > self.data.select(pl.last("time_stamp")).item()
-            or offset_timestamp < self.data.select(pl.first("time_stamp")).item()):
+        if (
+            onset_timestamp > self.data.select(pl.last("time_stamp")).item()
+            or offset_timestamp < self.data.select(pl.first("time_stamp")).item()
+        ):
             raise ValueError("Onset or offset timestamps are out of bounds.")
 
-        if (self.data.select(pl.first("time_stamp")).item() < onset_timestamp 
-            or self.data.select(pl.last("time_stamp")).item() > offset_timestamp):
+        if (
+            self.data.select(pl.first("time_stamp")).item() < onset_timestamp
+            or self.data.select(pl.last("time_stamp")).item() > offset_timestamp
+        ):
             raise ValueError("Data has not been filtered to specified time range.")
 
         modality_amount = self.data.select(
-        (pl.last("time_stamp") - pl.first("time_stamp")).alias("difference")
+            (pl.last("time_stamp") - pl.first("time_stamp")).alias("difference")
         ).item()
 
         timestamp_amount = offset_timestamp - onset_timestamp

--- a/src/MOBI_QC/core/models/DataStream.py
+++ b/src/MOBI_QC/core/models/DataStream.py
@@ -70,6 +70,24 @@ class DataStream:
         self.qc_metrics: dict[str, object] = {}
         self.error = False
 
+    def _check_timestamp_args(
+            self, onset_timestamp: float, offset_timestamp: float
+            ) -> None:
+        """Helper function to check timestamp arguments."""
+
+        if offset_timestamp < 0 or onset_timestamp < 0:
+            raise ValueError("Onset and offset timestamps must be positive values.")
+
+        if offset_timestamp <= onset_timestamp:
+            raise ValueError("Offset timestamp must be greater than onset timestamp.")
+
+        if (onset_timestamp > self.data.select(pl.last("time_stamp")).item()):
+            raise ValueError("Onset timestamp is out of bounds.") 
+             
+        if (offset_timestamp < self.data.select(pl.first("time_stamp")).item()):
+            raise ValueError("Offset timestamp is out of bounds.")
+
+
     def filter_time_range(
         self, onset_timestamp: float, offset_timestamp: float
     ) -> None:
@@ -137,17 +155,8 @@ class DataStream:
                         If onset and offset timestamps are out of bounds.
                         If data has not been filtered to the specified time range.
         """
-        if offset_timestamp < 0 or onset_timestamp < 0:
-            raise ValueError("Onset and offset timestamps must be positive values.")
 
-        if offset_timestamp <= onset_timestamp:
-            raise ValueError("Offset timestamp must be greater than onset timestamp.")
-
-        if (
-            onset_timestamp > self.data.select(pl.last("time_stamp")).item()
-            or offset_timestamp < self.data.select(pl.first("time_stamp")).item()
-        ):
-            raise ValueError("Onset or offset timestamps are out of bounds.")
+        self._check_timestamp_args(onset_timestamp, offset_timestamp)
 
         if (
             self.data.select(pl.first("time_stamp")).item() < onset_timestamp
@@ -156,8 +165,7 @@ class DataStream:
             raise ValueError("Data has not been filtered to specified time range.")
 
         modality_amount = self.data.select(
-            (pl.last("time_stamp") - pl.first("time_stamp")).alias("difference")
-        ).item()
+            pl.last("time_stamp") - pl.first("time_stamp")).item()
 
         timestamp_amount = offset_timestamp - onset_timestamp
 

--- a/src/MOBI_QC/core/models/DataStream.py
+++ b/src/MOBI_QC/core/models/DataStream.py
@@ -74,7 +74,6 @@ class DataStream:
             self, onset_timestamp: float, offset_timestamp: float
             ) -> None:
         """Helper function to check timestamp arguments."""
-
         if offset_timestamp < 0 or onset_timestamp < 0:
             raise ValueError("Onset and offset timestamps must be positive values.")
 
@@ -86,7 +85,6 @@ class DataStream:
              
         if (offset_timestamp < self.data.select(pl.first("time_stamp")).item()):
             raise ValueError("Offset timestamp is out of bounds.")
-
 
     def filter_time_range(
         self, onset_timestamp: float, offset_timestamp: float
@@ -129,7 +127,7 @@ class DataStream:
         else:
             self.effective_srate = 0
 
-    def amount_of_data(
+    def calculate_amount_of_data(
         self, onset_timestamp: float, offset_timestamp: float
     ) -> tuple[float, float]:
         """Calculate amount of data within time range.
@@ -155,7 +153,6 @@ class DataStream:
                         If onset and offset timestamps are out of bounds.
                         If data has not been filtered to the specified time range.
         """
-
         self._check_timestamp_args(onset_timestamp, offset_timestamp)
 
         if (

--- a/src/MOBI_QC/core/models/DataStream.py
+++ b/src/MOBI_QC/core/models/DataStream.py
@@ -110,3 +110,53 @@ class DataStream:
             self.effective_srate = 1 / time_stamp_diff
         else:
             self.effective_srate = 0
+
+    def calculate_durations_within_range(
+        self, onset_timestamp: float, offset_timestamp: float
+    ) -> tuple[float, float]:
+        """Calculate duration within time range.
+
+        Calculate duration of filtered modality data within specified time range, 
+        based on LSL timestamps, and compares it with the expected duration within 
+        that time range.
+
+        Args:
+            onset_timestamp: start time (seconds) of time range for calculating duration
+            offset_timestamp: end time (seconds) of time range for calculating duration
+
+        Returns:
+            A tuple containing:
+                - modality_duration: Duration of modality data within the specified 
+                time range (in seconds).
+                - duration_percent: Percentage of expected duration that the modality
+                duration represents.
+
+        Raises:
+            ValueError: If offset_timestamp is less than or equal to onset_timestamp.
+                        If either onset_timestamp or offset_timestamp is negative.
+                        If onset and offset timestamps are out of bounds.
+                        If data has not been filtered to the specified time range.
+        """
+        if offset_timestamp < 0 or onset_timestamp < 0:
+            raise ValueError("Onset and offset timestamps must be positive values.")
+
+        if offset_timestamp <= onset_timestamp:
+            raise ValueError("Offset timestamp must be greater than onset timestamp.")
+
+        if (onset_timestamp > self.data.select(pl.last("time_stamp")).item()
+            or offset_timestamp < self.data.select(pl.first("time_stamp")).item()):
+            raise ValueError("Onset or offset timestamps are out of bounds.")
+
+        if (self.data.select(pl.first("time_stamp")).item() < onset_timestamp 
+            or self.data.select(pl.last("time_stamp")).item() > offset_timestamp):
+            raise ValueError("Data has not been filtered to specified time range.")
+
+        modality_duration = self.data.select(
+        (pl.last("time_stamp") - pl.first("time_stamp")).alias("difference")
+        ).item()
+
+        timestamp_duration = offset_timestamp - onset_timestamp
+
+        duration_percent = (modality_duration / timestamp_duration) * 100
+
+        return modality_duration, duration_percent

--- a/src/MOBI_QC/core/models/DataStream.py
+++ b/src/MOBI_QC/core/models/DataStream.py
@@ -111,25 +111,25 @@ class DataStream:
         else:
             self.effective_srate = 0
 
-    def calculate_durations_within_range(
+    def amount_of_data(
         self, onset_timestamp: float, offset_timestamp: float
     ) -> tuple[float, float]:
-        """Calculate duration within time range.
+        """Calculate amount of data within time range.
 
-        Calculate duration of filtered modality data within specified time range, 
-        based on LSL timestamps, and compares it with the expected duration within 
-        that time range.
+        Calculate amount of data within filtered modality data for specified time 
+        range, based on LSL timestamps, and compare it with the expected amount in 
+        that time range which is calculated from input onset and offset timestamps.
 
         Args:
-            onset_timestamp: start time (seconds) of time range for calculating duration
-            offset_timestamp: end time (seconds) of time range for calculating duration
+            onset_timestamp: start time (seconds) of time range for calculating amount
+            offset_timestamp: end time (seconds) of time range for calculating amount
 
         Returns:
             A tuple containing:
-                - modality_duration: Duration of modality data within the specified 
+                - modality_amount: Amount of modality data within the specified 
                 time range (in seconds).
-                - duration_percent: Percentage of expected duration that the modality
-                duration represents.
+                - amount_percent: Percentage of expected amount that the modality
+                amount represents.
 
         Raises:
             ValueError: If offset_timestamp is less than or equal to onset_timestamp.
@@ -151,12 +151,12 @@ class DataStream:
             or self.data.select(pl.last("time_stamp")).item() > offset_timestamp):
             raise ValueError("Data has not been filtered to specified time range.")
 
-        modality_duration = self.data.select(
+        modality_amount = self.data.select(
         (pl.last("time_stamp") - pl.first("time_stamp")).alias("difference")
         ).item()
 
-        timestamp_duration = offset_timestamp - onset_timestamp
+        timestamp_amount = offset_timestamp - onset_timestamp
 
-        duration_percent = (modality_duration / timestamp_duration) * 100
+        amount_percent = (modality_amount / timestamp_amount) * 100
 
-        return modality_duration, duration_percent
+        return modality_amount, amount_percent

--- a/src/MOBI_QC/core/models/DataStream.py
+++ b/src/MOBI_QC/core/models/DataStream.py
@@ -71,8 +71,8 @@ class DataStream:
         self.error = False
 
     def _check_timestamp_args(
-            self, onset_timestamp: float, offset_timestamp: float
-            ) -> None:
+        self, onset_timestamp: float, offset_timestamp: float
+    ) -> None:
         """Helper function to check timestamp arguments."""
         if offset_timestamp < 0 or onset_timestamp < 0:
             raise ValueError("Onset and offset timestamps must be positive values.")
@@ -80,10 +80,10 @@ class DataStream:
         if offset_timestamp <= onset_timestamp:
             raise ValueError("Offset timestamp must be greater than onset timestamp.")
 
-        if (onset_timestamp > self.data.select(pl.last("time_stamp")).item()):
-            raise ValueError("Onset timestamp is out of bounds.") 
-             
-        if (offset_timestamp < self.data.select(pl.first("time_stamp")).item()):
+        if onset_timestamp > self.data.select(pl.last("time_stamp")).item():
+            raise ValueError("Onset timestamp is out of bounds.")
+
+        if offset_timestamp < self.data.select(pl.first("time_stamp")).item():
             raise ValueError("Offset timestamp is out of bounds.")
 
     def filter_time_range(
@@ -162,7 +162,8 @@ class DataStream:
             raise ValueError("Data has not been filtered to specified time range.")
 
         modality_amount = self.data.select(
-            pl.last("time_stamp") - pl.first("time_stamp")).item()
+            pl.last("time_stamp") - pl.first("time_stamp")
+        ).item()
 
         timestamp_amount = offset_timestamp - onset_timestamp
 

--- a/tests/unit/test_datastream.py
+++ b/tests/unit/test_datastream.py
@@ -27,20 +27,25 @@ def test_datastream_initialization(
     assert hasattr(sample_datastream_obj, "error")
     assert not sample_datastream_obj.error
 
+
 @pytest.mark.parametrize(
     "onset_timestamp, offset_timestamp, expected_message",
     [
         (-100.0, -10.0, "Onset and offset timestamps must be positive values."),
         (10.0, -100.0, "Onset and offset timestamps must be positive values."),
-        (100.0, 10.0, "Offset timestamp must be greater than onset timestamp."), 
+        (100.0, 10.0, "Offset timestamp must be greater than onset timestamp."),
         (100.0, 100.0, "Offset timestamp must be greater than onset timestamp."),
-        ("sample_datastream_obj.data.select(pl.last('time_stamp')).item() + 10",
-         "sample_datastream_obj.data.select(pl.last('time_stamp')).item() + 20",
-         "Onset timestamp is out of bounds."),
-        ("sample_datastream_obj.data.select(pl.first('time_stamp')).item() - 20",
-         "sample_datastream_obj.data.select(pl.first('time_stamp')).item() - 10",
-         "Offset timestamp is out of bounds.")
-    ]
+        (
+            "sample_datastream_obj.data.select(pl.last('time_stamp')).item() + 10",
+            "sample_datastream_obj.data.select(pl.last('time_stamp')).item() + 20",
+            "Onset timestamp is out of bounds.",
+        ),
+        (
+            "sample_datastream_obj.data.select(pl.first('time_stamp')).item() - 20",
+            "sample_datastream_obj.data.select(pl.first('time_stamp')).item() - 10",
+            "Offset timestamp is out of bounds.",
+        ),
+    ],
 )
 def test_check_timestamp_args_raises_value_error(
     sample_datastream_obj: DataStream.DataStream,
@@ -50,9 +55,9 @@ def test_check_timestamp_args_raises_value_error(
 ) -> None:
     """Test that _check_timestamp_args raises ValueError for invalid timestamps."""
     if isinstance(onset_timestamp, str):
-         onset_timestamp = eval(onset_timestamp)
+        onset_timestamp = eval(onset_timestamp)
     if isinstance(offset_timestamp, str):
-         offset_timestamp = eval(offset_timestamp)
+        offset_timestamp = eval(offset_timestamp)
     with pytest.raises(ValueError, match=expected_message):
         sample_datastream_obj._check_timestamp_args(onset_timestamp, offset_timestamp)
 
@@ -99,7 +104,8 @@ def test_raises_value_error_if_data_not_filtered(
         ValueError, match="Data has not been filtered to specified time range."
     ):
         sample_datastream_obj.calculate_amount_of_data(
-            onset_timestamp, offset_timestamp)
+            onset_timestamp, offset_timestamp
+        )
 
 
 def test_datastream_calculate_amount_of_data(

--- a/tests/unit/test_datastream.py
+++ b/tests/unit/test_datastream.py
@@ -93,3 +93,107 @@ def test_datastream_filter_time_range(
     assert math.isclose(
         sample_datastream_obj.effective_srate, expected_fs, rel_tol=10e-7
     )
+
+
+def test_calculate_durations_raises_value_error_if_offset_less(
+    sample_datastream_obj: DataStream.DataStream,
+) -> None:
+    """Test that ValueError is raised when offset timestamp is less than onset."""
+    onset_timestamp = 100.0
+    offset_timestamp = 10.0
+    with pytest.raises(
+        ValueError, match="Offset timestamp must be greater than onset timestamp."
+    ):
+        sample_datastream_obj.calculate_durations_within_range(
+            onset_timestamp, offset_timestamp
+        )
+
+
+def test_calculate_durations_raises_value_error_if_offset_onset_equal(
+    sample_datastream_obj: DataStream.DataStream,
+) -> None:
+    """Test that ValueError is raised when offset and onset timestamps are equal."""
+    timestamp = 100.0
+    with pytest.raises(
+        ValueError, match="Offset timestamp must be greater than onset timestamp."
+    ):
+        sample_datastream_obj.calculate_durations_within_range(timestamp, timestamp)
+
+
+def test_calculate_durations_raises_value_error_if_timestamps_negative(
+    sample_datastream_obj: DataStream.DataStream,
+) -> None:
+    """Test that ValueError is raised when onset or offset timestamps are negative."""
+    onset_timestamp = -100.0
+    offset_timestamp = -10.0
+    with pytest.raises(
+        ValueError, match="Onset and offset timestamps must be positive values."
+    ):
+        sample_datastream_obj.calculate_durations_within_range(
+            onset_timestamp, offset_timestamp
+        )
+
+def test_calculate_durations_raises_value_error_if_onset_out_of_bounds(
+    sample_datastream_obj: DataStream.DataStream,
+) -> None:
+    """Test that ValueError is raised when onset timestamp is out of bounds."""
+    onset_timestamp = sample_datastream_obj.data.item(-1, "time_stamp") + 10
+    offset_timestamp = sample_datastream_obj.data.item(-1, "time_stamp") +20
+    with pytest.raises(
+        ValueError, match="Onset or offset timestamps are out of bounds."
+    ):
+        sample_datastream_obj.calculate_durations_within_range(
+            onset_timestamp, offset_timestamp
+        )
+
+def test_calculate_durations_raises_value_error_if_offset_out_of_bounds(
+    sample_datastream_obj: DataStream.DataStream,
+) -> None:
+    """Test that ValueError is raised when offset timestamp is out of bounds."""
+    onset_timestamp = sample_datastream_obj.data.item(0, "time_stamp") - 20
+    offset_timestamp = sample_datastream_obj.data.item(0, "time_stamp") - 10
+    with pytest.raises(
+        ValueError, match="Onset or offset timestamps are out of bounds."
+    ):
+        sample_datastream_obj.calculate_durations_within_range(
+            onset_timestamp, offset_timestamp
+        )
+
+def test_raises_value_error_if_data_not_filtered(
+    sample_datastream_obj: DataStream.DataStream,
+) -> None:
+    """Test that ValueError is raised when data has not been filtered to time range."""
+    onset_timestamp = sample_datastream_obj.data.item(10, "time_stamp")
+    offset_timestamp = sample_datastream_obj.data.item(-1, "time_stamp") - 10
+    with pytest.raises(
+        ValueError, match="Data has not been filtered to specified time range."
+    ):
+        sample_datastream_obj.calculate_durations_within_range(
+            onset_timestamp, offset_timestamp
+        )
+
+def test_calculate_durations_within_range(
+    sample_datastream_obj: DataStream.DataStream,
+) -> None:
+    """Test DataStream calculate_durations_within_range method."""
+    onset_index = 10
+    offset_index = 100
+    onset_timestamp = sample_datastream_obj.data.item(onset_index, "time_stamp")
+    offset_timestamp = sample_datastream_obj.data.item(offset_index, "time_stamp")
+    expected_duration = offset_timestamp - onset_timestamp
+    expected_percent = 100.0
+
+    sample_datastream_obj.data = sample_datastream_obj.data.filter(
+        (pl.col("time_stamp") >= onset_timestamp)
+        & (pl.col("time_stamp") <= offset_timestamp)
+    )
+
+    modality_duration, duration_percent = (
+        sample_datastream_obj.calculate_durations_within_range(
+            onset_timestamp,
+            offset_timestamp,
+        )
+    )
+
+    assert modality_duration == expected_duration
+    assert math.isclose(duration_percent, expected_percent, rel_tol=10e-7)

--- a/tests/unit/test_datastream.py
+++ b/tests/unit/test_datastream.py
@@ -104,9 +104,7 @@ def test_amount_of_data_raises_value_error_if_offset_less(
     with pytest.raises(
         ValueError, match="Offset timestamp must be greater than onset timestamp."
     ):
-        sample_datastream_obj.amount_of_data(
-            onset_timestamp, offset_timestamp
-        )
+        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
 
 
 def test_amount_of_data_raises_value_error_if_offset_onset_equal(
@@ -129,22 +127,20 @@ def test_amount_of_data_raises_value_error_if_timestamps_negative(
     with pytest.raises(
         ValueError, match="Onset and offset timestamps must be positive values."
     ):
-        sample_datastream_obj.amount_of_data(
-            onset_timestamp, offset_timestamp
-        )
+        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
+
 
 def test_amount_of_data_raises_value_error_if_onset_out_of_bounds(
     sample_datastream_obj: DataStream.DataStream,
 ) -> None:
     """Test that ValueError is raised when onset timestamp is out of bounds."""
     onset_timestamp = sample_datastream_obj.data.item(-1, "time_stamp") + 10
-    offset_timestamp = sample_datastream_obj.data.item(-1, "time_stamp") +20
+    offset_timestamp = sample_datastream_obj.data.item(-1, "time_stamp") + 20
     with pytest.raises(
         ValueError, match="Onset or offset timestamps are out of bounds."
     ):
-        sample_datastream_obj.amount_of_data(
-            onset_timestamp, offset_timestamp
-        )
+        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
+
 
 def test_amount_of_data_raises_value_error_if_offset_out_of_bounds(
     sample_datastream_obj: DataStream.DataStream,
@@ -155,9 +151,8 @@ def test_amount_of_data_raises_value_error_if_offset_out_of_bounds(
     with pytest.raises(
         ValueError, match="Onset or offset timestamps are out of bounds."
     ):
-        sample_datastream_obj.amount_of_data(
-            onset_timestamp, offset_timestamp
-        )
+        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
+
 
 def test_raises_value_error_if_data_not_filtered(
     sample_datastream_obj: DataStream.DataStream,
@@ -168,9 +163,8 @@ def test_raises_value_error_if_data_not_filtered(
     with pytest.raises(
         ValueError, match="Data has not been filtered to specified time range."
     ):
-        sample_datastream_obj.amount_of_data(
-            onset_timestamp, offset_timestamp
-        )
+        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
+
 
 def test_datastream_amount_of_data(
     sample_datastream_obj: DataStream.DataStream,
@@ -188,11 +182,9 @@ def test_datastream_amount_of_data(
         & (pl.col("time_stamp") <= offset_timestamp)
     )
 
-    modality_amount, amount_percent = (
-        sample_datastream_obj.amount_of_data(
-            onset_timestamp,
-            offset_timestamp,
-        )
+    modality_amount, amount_percent = sample_datastream_obj.amount_of_data(
+        onset_timestamp,
+        offset_timestamp,
     )
 
     assert modality_amount == expected_amount

--- a/tests/unit/test_datastream.py
+++ b/tests/unit/test_datastream.py
@@ -95,7 +95,7 @@ def test_datastream_filter_time_range(
     )
 
 
-def test_calculate_durations_raises_value_error_if_offset_less(
+def test_amount_of_data_raises_value_error_if_offset_less(
     sample_datastream_obj: DataStream.DataStream,
 ) -> None:
     """Test that ValueError is raised when offset timestamp is less than onset."""
@@ -104,12 +104,12 @@ def test_calculate_durations_raises_value_error_if_offset_less(
     with pytest.raises(
         ValueError, match="Offset timestamp must be greater than onset timestamp."
     ):
-        sample_datastream_obj.calculate_durations_within_range(
+        sample_datastream_obj.amount_of_data(
             onset_timestamp, offset_timestamp
         )
 
 
-def test_calculate_durations_raises_value_error_if_offset_onset_equal(
+def test_amount_of_data_raises_value_error_if_offset_onset_equal(
     sample_datastream_obj: DataStream.DataStream,
 ) -> None:
     """Test that ValueError is raised when offset and onset timestamps are equal."""
@@ -117,10 +117,10 @@ def test_calculate_durations_raises_value_error_if_offset_onset_equal(
     with pytest.raises(
         ValueError, match="Offset timestamp must be greater than onset timestamp."
     ):
-        sample_datastream_obj.calculate_durations_within_range(timestamp, timestamp)
+        sample_datastream_obj.amount_of_data(timestamp, timestamp)
 
 
-def test_calculate_durations_raises_value_error_if_timestamps_negative(
+def test_amount_of_data_raises_value_error_if_timestamps_negative(
     sample_datastream_obj: DataStream.DataStream,
 ) -> None:
     """Test that ValueError is raised when onset or offset timestamps are negative."""
@@ -129,11 +129,11 @@ def test_calculate_durations_raises_value_error_if_timestamps_negative(
     with pytest.raises(
         ValueError, match="Onset and offset timestamps must be positive values."
     ):
-        sample_datastream_obj.calculate_durations_within_range(
+        sample_datastream_obj.amount_of_data(
             onset_timestamp, offset_timestamp
         )
 
-def test_calculate_durations_raises_value_error_if_onset_out_of_bounds(
+def test_amount_of_data_raises_value_error_if_onset_out_of_bounds(
     sample_datastream_obj: DataStream.DataStream,
 ) -> None:
     """Test that ValueError is raised when onset timestamp is out of bounds."""
@@ -142,11 +142,11 @@ def test_calculate_durations_raises_value_error_if_onset_out_of_bounds(
     with pytest.raises(
         ValueError, match="Onset or offset timestamps are out of bounds."
     ):
-        sample_datastream_obj.calculate_durations_within_range(
+        sample_datastream_obj.amount_of_data(
             onset_timestamp, offset_timestamp
         )
 
-def test_calculate_durations_raises_value_error_if_offset_out_of_bounds(
+def test_amount_of_data_raises_value_error_if_offset_out_of_bounds(
     sample_datastream_obj: DataStream.DataStream,
 ) -> None:
     """Test that ValueError is raised when offset timestamp is out of bounds."""
@@ -155,7 +155,7 @@ def test_calculate_durations_raises_value_error_if_offset_out_of_bounds(
     with pytest.raises(
         ValueError, match="Onset or offset timestamps are out of bounds."
     ):
-        sample_datastream_obj.calculate_durations_within_range(
+        sample_datastream_obj.amount_of_data(
             onset_timestamp, offset_timestamp
         )
 
@@ -168,19 +168,19 @@ def test_raises_value_error_if_data_not_filtered(
     with pytest.raises(
         ValueError, match="Data has not been filtered to specified time range."
     ):
-        sample_datastream_obj.calculate_durations_within_range(
+        sample_datastream_obj.amount_of_data(
             onset_timestamp, offset_timestamp
         )
 
-def test_calculate_durations_within_range(
+def test_datastream_amount_of_data(
     sample_datastream_obj: DataStream.DataStream,
 ) -> None:
-    """Test DataStream calculate_durations_within_range method."""
+    """Test DataStream amount_of_data method."""
     onset_index = 10
     offset_index = 100
     onset_timestamp = sample_datastream_obj.data.item(onset_index, "time_stamp")
     offset_timestamp = sample_datastream_obj.data.item(offset_index, "time_stamp")
-    expected_duration = offset_timestamp - onset_timestamp
+    expected_amount = offset_timestamp - onset_timestamp
     expected_percent = 100.0
 
     sample_datastream_obj.data = sample_datastream_obj.data.filter(
@@ -188,12 +188,12 @@ def test_calculate_durations_within_range(
         & (pl.col("time_stamp") <= offset_timestamp)
     )
 
-    modality_duration, duration_percent = (
-        sample_datastream_obj.calculate_durations_within_range(
+    modality_amount, amount_percent = (
+        sample_datastream_obj.amount_of_data(
             onset_timestamp,
             offset_timestamp,
         )
     )
 
-    assert modality_duration == expected_duration
-    assert math.isclose(duration_percent, expected_percent, rel_tol=10e-7)
+    assert modality_amount == expected_amount
+    assert math.isclose(amount_percent, expected_percent, rel_tol=10e-7)

--- a/tests/unit/test_datastream.py
+++ b/tests/unit/test_datastream.py
@@ -27,40 +27,26 @@ def test_datastream_initialization(
     assert hasattr(sample_datastream_obj, "error")
     assert not sample_datastream_obj.error
 
-
-def test_raises_value_error_if_offset_less(
+@pytest.mark.parametrize(
+    "onset_timestamp, offset_timestamp, expected_message",
+    [
+        (-100.0, -10.0, "Onset and offset timestamps must be positive values."),
+        (10.0, -100.0, "Onset and offset timestamps must be positive values."),
+        (100.0, 10.0, "Offset timestamp must be greater than onset timestamp."), 
+        (100.0, 100.0, "Offset timestamp must be greater than onset timestamp.")
+    ]
+)
+def test_check_timestamp_args_raises_value_error(
     sample_datastream_obj: DataStream.DataStream,
+    onset_timestamp: float,
+    offset_timestamp: float,
+    expected_message: str,
 ) -> None:
-    """Test that ValueError is raised when offset timestamp is less than onset."""
-    onset_timestamp = 100.0
-    offset_timestamp = 10.0
-    with pytest.raises(
-        ValueError, match="Offset timestamp must be greater than onset timestamp."
-    ):
-        sample_datastream_obj.filter_time_range(onset_timestamp, offset_timestamp)
+    """Test that _check_timestamp_args raises ValueError for invalid timestamps."""
 
+    with pytest.raises(ValueError, match=expected_message):
+        sample_datastream_obj._check_timestamp_args(onset_timestamp, offset_timestamp)
 
-def test_raises_value_error_if_offset_onset_equal(
-    sample_datastream_obj: DataStream.DataStream,
-) -> None:
-    """Test that ValueError is raised when offset and onset timestamps are equal."""
-    timestamp = 100.0
-    with pytest.raises(
-        ValueError, match="Offset timestamp must be greater than onset timestamp."
-    ):
-        sample_datastream_obj.filter_time_range(timestamp, timestamp)
-
-
-def test_raises_value_error_if_timestamps_negative(
-    sample_datastream_obj: DataStream.DataStream,
-) -> None:
-    """Test that ValueError is raised when onset or offset timestamps are negative."""
-    onset_timestamp = -100.0
-    offset_timestamp = -10.0
-    with pytest.raises(
-        ValueError, match="Onset and offset timestamps must be positive values."
-    ):
-        sample_datastream_obj.filter_time_range(onset_timestamp, offset_timestamp)
 
 
 def test_fs_zero_if_df_empty(
@@ -93,41 +79,6 @@ def test_datastream_filter_time_range(
     assert math.isclose(
         sample_datastream_obj.effective_srate, expected_fs, rel_tol=10e-7
     )
-
-
-def test_amount_of_data_raises_value_error_if_offset_less(
-    sample_datastream_obj: DataStream.DataStream,
-) -> None:
-    """Test that ValueError is raised when offset timestamp is less than onset."""
-    onset_timestamp = 100.0
-    offset_timestamp = 10.0
-    with pytest.raises(
-        ValueError, match="Offset timestamp must be greater than onset timestamp."
-    ):
-        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
-
-
-def test_amount_of_data_raises_value_error_if_offset_onset_equal(
-    sample_datastream_obj: DataStream.DataStream,
-) -> None:
-    """Test that ValueError is raised when offset and onset timestamps are equal."""
-    timestamp = 100.0
-    with pytest.raises(
-        ValueError, match="Offset timestamp must be greater than onset timestamp."
-    ):
-        sample_datastream_obj.amount_of_data(timestamp, timestamp)
-
-
-def test_amount_of_data_raises_value_error_if_timestamps_negative(
-    sample_datastream_obj: DataStream.DataStream,
-) -> None:
-    """Test that ValueError is raised when onset or offset timestamps are negative."""
-    onset_timestamp = -100.0
-    offset_timestamp = -10.0
-    with pytest.raises(
-        ValueError, match="Onset and offset timestamps must be positive values."
-    ):
-        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
 
 
 def test_amount_of_data_raises_value_error_if_onset_out_of_bounds(

--- a/tests/unit/test_datastream.py
+++ b/tests/unit/test_datastream.py
@@ -33,7 +33,13 @@ def test_datastream_initialization(
         (-100.0, -10.0, "Onset and offset timestamps must be positive values."),
         (10.0, -100.0, "Onset and offset timestamps must be positive values."),
         (100.0, 10.0, "Offset timestamp must be greater than onset timestamp."), 
-        (100.0, 100.0, "Offset timestamp must be greater than onset timestamp.")
+        (100.0, 100.0, "Offset timestamp must be greater than onset timestamp."),
+        ("sample_datastream_obj.data.select(pl.last('time_stamp')).item() + 10",
+         "sample_datastream_obj.data.select(pl.last('time_stamp')).item() + 20",
+         "Onset timestamp is out of bounds."),
+        ("sample_datastream_obj.data.select(pl.first('time_stamp')).item() - 20",
+         "sample_datastream_obj.data.select(pl.first('time_stamp')).item() - 10",
+         "Offset timestamp is out of bounds.")
     ]
 )
 def test_check_timestamp_args_raises_value_error(
@@ -43,10 +49,12 @@ def test_check_timestamp_args_raises_value_error(
     expected_message: str,
 ) -> None:
     """Test that _check_timestamp_args raises ValueError for invalid timestamps."""
-
+    if isinstance(onset_timestamp, str):
+         onset_timestamp = eval(onset_timestamp)
+    if isinstance(offset_timestamp, str):
+         offset_timestamp = eval(offset_timestamp)
     with pytest.raises(ValueError, match=expected_message):
         sample_datastream_obj._check_timestamp_args(onset_timestamp, offset_timestamp)
-
 
 
 def test_fs_zero_if_df_empty(
@@ -81,30 +89,6 @@ def test_datastream_filter_time_range(
     )
 
 
-def test_amount_of_data_raises_value_error_if_onset_out_of_bounds(
-    sample_datastream_obj: DataStream.DataStream,
-) -> None:
-    """Test that ValueError is raised when onset timestamp is out of bounds."""
-    onset_timestamp = sample_datastream_obj.data.item(-1, "time_stamp") + 10
-    offset_timestamp = sample_datastream_obj.data.item(-1, "time_stamp") + 20
-    with pytest.raises(
-        ValueError, match="Onset or offset timestamps are out of bounds."
-    ):
-        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
-
-
-def test_amount_of_data_raises_value_error_if_offset_out_of_bounds(
-    sample_datastream_obj: DataStream.DataStream,
-) -> None:
-    """Test that ValueError is raised when offset timestamp is out of bounds."""
-    onset_timestamp = sample_datastream_obj.data.item(0, "time_stamp") - 20
-    offset_timestamp = sample_datastream_obj.data.item(0, "time_stamp") - 10
-    with pytest.raises(
-        ValueError, match="Onset or offset timestamps are out of bounds."
-    ):
-        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
-
-
 def test_raises_value_error_if_data_not_filtered(
     sample_datastream_obj: DataStream.DataStream,
 ) -> None:
@@ -114,10 +98,11 @@ def test_raises_value_error_if_data_not_filtered(
     with pytest.raises(
         ValueError, match="Data has not been filtered to specified time range."
     ):
-        sample_datastream_obj.amount_of_data(onset_timestamp, offset_timestamp)
+        sample_datastream_obj.calculate_amount_of_data(
+            onset_timestamp, offset_timestamp)
 
 
-def test_datastream_amount_of_data(
+def test_datastream_calculate_amount_of_data(
     sample_datastream_obj: DataStream.DataStream,
 ) -> None:
     """Test DataStream amount_of_data method."""
@@ -133,7 +118,7 @@ def test_datastream_amount_of_data(
         & (pl.col("time_stamp") <= offset_timestamp)
     )
 
-    modality_amount, amount_percent = sample_datastream_obj.amount_of_data(
+    modality_amount, amount_percent = sample_datastream_obj.calculate_amount_of_data(
         onset_timestamp,
         offset_timestamp,
     )


### PR DESCRIPTION
This PR addresses #124 and calculates the amount of data in a modality stream within a specified time range. It also compares the amount to the expected amount based on input onset and offset timestamps, and calculates a percentage of amount of data. It returns the values for the amount of data  (in seconds) and the amount percentage.